### PR TITLE
switch from using client to pool; bump version to 0.3.0

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,5 @@
-import { Client, QueryConfig, QueryResult } from "pg";
-export declare let client: Client | null;
+import { Pool, QueryConfig, QueryResult } from "pg";
+export declare let pool: Pool | null;
 export declare function connect(): Promise<void>;
 export declare function disconnect(): Promise<void>;
 export declare function query(queryTextOrConfig: string | QueryConfig, values?: any[]): Promise<QueryResult>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const crypto_1 = require("crypto");
 const pg_1 = require("pg");
 async function connect() {
-    if (!exports.client) {
+    if (!exports.pool) {
         let config;
         if (process.env.PGCONNECTIONSTRING) {
             config = {
@@ -28,38 +28,55 @@ async function connect() {
         else {
             throw new Error("Set PostgreSQL environment variables PGUSER, PGHOST, PGPASSWORD, PGDATABASE, PGPORT or PGCONNECTIONSTRING");
         }
-        exports.client = new pg_1.Client(config);
-        await exports.client.connect();
+        exports.pool = new pg_1.Pool(config);
+        exports.pool.on("error", (err, client) => {
+            console.error("postgres pool client error:");
+            console.error(err);
+        });
+        // For development only
+        // pool.on("connect", (client: PoolClient) => {
+        //   console.log("pg client connected");
+        // });
+        // pool.on("acquire", (client: PoolClient) => {
+        //   console.log("pg client acquired");
+        // });
+        // pool.on("remove", (client: PoolClient) => {
+        //   console.log("pg client removed");
+        // });
     }
 }
 exports.connect = connect;
 async function disconnect() {
-    if (exports.client) {
-        await exports.client.end();
-        exports.client = null;
+    if (exports.pool) {
+        await exports.pool.end();
+        exports.pool = null;
     }
 }
 exports.disconnect = disconnect;
 async function query(...args) {
-    if (!exports.client) {
+    if (!exports.pool) {
         await connect();
     }
-    return exports.client.query.apply(exports.client, args);
+    return exports.pool.query.apply(exports.pool, args);
 }
 exports.query = query;
 async function transaction(commands = []) {
-    if (!exports.client) {
+    if (!exports.pool) {
         await connect();
     }
+    const client = await exports.pool.connect();
     try {
-        await exports.client.query("BEGIN");
-        const result = await Promise.all(commands.map(command => exports.client.query(command)));
-        await exports.client.query("COMMIT");
+        await client.query("BEGIN");
+        const result = await Promise.all(commands.map(command => exports.pool.query(command)));
+        await client.query("COMMIT");
         return result;
     }
     catch (e) {
-        await exports.client.query("ROLLBACK");
+        await client.query("ROLLBACK");
         throw e;
+    }
+    finally {
+        client.release();
     }
 }
 exports.transaction = transaction;
@@ -69,11 +86,11 @@ function hashString(string) {
         .digest("hex");
 }
 async function executeImmutableSequence(sequenceName, commands = []) {
-    if (!exports.client) {
+    if (!exports.pool) {
         await connect();
     }
     // create the migrations table if it does not exist
-    await exports.client.query(`CREATE TABLE IF NOT EXISTS ${sequenceName} (
+    await exports.pool.query(`CREATE TABLE IF NOT EXISTS ${sequenceName} (
     id        serial PRIMARY KEY,
     version   integer NOT NULL,
     run_at    timestamp WITH TIME ZONE DEFAULT current_timestamp,
@@ -84,7 +101,7 @@ async function executeImmutableSequence(sequenceName, commands = []) {
     // check for changes in any migrations that have already been run
     for (let i = 0; i < commands.length; i++) {
         const expectedHash = hashString(commands[i]);
-        const existingCommandResult = await exports.client.query(`SELECT * FROM ${sequenceName} WHERE version=$1`, [i]);
+        const existingCommandResult = await exports.pool.query(`SELECT * FROM ${sequenceName} WHERE version=$1`, [i]);
         const existingCommand = existingCommandResult.rows && existingCommandResult.rows[0];
         if (existingCommand) {
             latestCommandVersion++;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@useful/postgresql",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,17 +10,17 @@
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/node": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.1.3.tgz",
-      "integrity": "sha512-GiCx7dRvta0hbxXoJFAUxz+CKX6bZSCKjM5slq2vPp/5zwK01T4ibYZkGr6EN4F2QmxDQR76/ZHg6q+7iFWCWw=="
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
+      "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
     },
     "@types/pg": {
-      "version": "7.4.9",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.4.9.tgz",
-      "integrity": "sha512-OeoNfrNanxVN5wnB9zcIfeoNsKWyhcdtd3cZOYU3JGBGX4fXhKNDpmcXuQ1NAeG8JSNWPIi5MVqh8ZhY4Pk6iA==",
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-7.4.10.tgz",
+      "integrity": "sha512-IQ9vRZ3oX99TXZiVq5PgODNoqgHvn2girbkxa6gBT7DPGgvRiJ7kZNwmPiLqSOzlRgMHBIujFeiwD5Sf5TIJqg==",
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "10.1.3",
+        "@types/node": "10.9.4",
         "@types/pg-types": "1.11.4"
       }
     },
@@ -29,7 +29,7 @@
       "resolved": "https://registry.npmjs.org/@types/pg-types/-/pg-types-1.11.4.tgz",
       "integrity": "sha512-WdIiQmE347LGc1Vq3Ki8sk3iyCuLgnccqVzgxek6gEHp2H0p3MQ3jniIHt+bRODXKju4kNQ+mp53lmP5+/9moQ==",
       "requires": {
-        "moment": "2.22.1"
+        "moment": "2.22.2"
       }
     },
     "bindings": {
@@ -67,9 +67,9 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "nan": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useful/postgresql",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "main": "dist/index.js",
   "license": "MIT",
   "authors": "Useful IO <team@useful.io>",
@@ -12,7 +12,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@types/pg": "^7.4.9",
+    "@types/pg": "^7.4.10",
     "pg": "^7.4.3",
     "pg-native": "^3.0.0"
   },


### PR DESCRIPTION
Purpose is to support serverless environments that do not reload node modules, so the client was being shared across executions that were asynchronously executing against it and then possibly calling disconnect.

This implementation exposes a single pool instead of a client, and disconnect is still available, but should not be called in a serverless environment (only in a single stand-alone program should disconnect be used). Clients in the pool auto disconnect after 10 seconds, querying is done primarily via `pool.query` which handles acquiring/releasing clients from the pool automatically.